### PR TITLE
Fixed sequence to kill remote shell.

### DIFF
--- a/crypt_unlock.sh
+++ b/crypt_unlock.sh
@@ -30,7 +30,7 @@ mount -o zfsutil -t zfs rpool/root /
 kill `ps | grep plymouth | grep -v "grep" | awk '{print $1}'` 
 kill `ps | grep cryptroot | grep -v "grep" | awk '{print $1}'`
 # following line kill the remote shell right after the passphrase has been entered. 
-kill -9 `ps | grep "-sh" | grep -v "grep" | awk '{print $1}'`
+kill -9 `ps | grep "\-sh" | grep -v "grep" | awk '{print $1}'`
 exit 0 
 fi 
 exit 1 


### PR DESCRIPTION
  - Added escape character in grep command which was failing otherwise.